### PR TITLE
Adds CORS credentials flag to settings/base

### DIFF
--- a/dsnap_registration_service/settings/base.py
+++ b/dsnap_registration_service/settings/base.py
@@ -35,6 +35,7 @@ CORS_ORIGIN_REGEX_WHITELIST = (
     r'^https?://dsnap-registration.*\.app\.cloud\.gov$'
 )
 
+CORS_ALLOW_CREDENTIALS = True
 
 # Application definition
 


### PR DESCRIPTION
* Allows CORS requests when `withCredentials` flag is set on the client